### PR TITLE
Migrationでエラーがでる

### DIFF
--- a/Config/Migration/1496878521_alter_event_add_calendar_key_and_timezone.php
+++ b/Config/Migration/1496878521_alter_event_add_calendar_key_and_timezone.php
@@ -28,14 +28,13 @@ class AlterEventAddCalendarKeyAndTimezone extends CakeMigration {
 		'up' => array(
 			'create_field' => array(
 				'reservation_events' => array(
-					'timezone' => array('type' => 'string', 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8', 'after' => 'timezone_offset'),
 					'calendar_key' => array('type' => 'string', 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8', 'after' => 'email_send_timing'),
 				),
 			),
 		),
 		'down' => array(
 			'drop_field' => array(
-				'reservation_events' => array('timezone', 'calendar_key'),
+				'reservation_events' => array('calendar_key'),
 			),
 		),
 	);


### PR DESCRIPTION
---------------------------------------------------------------
Running migrations:
  [1496878521] 1496878521_alter_event_add_calendar_key_and_timezone (2017-06-07 23:35:21)
An error occurred when processing the migration:
  Migration: 1496878521_alter_event_add_calendar_key_and_timezone
  Error: Field "timezone" already exists in "reservation_events".
---------------------------------------------------------------