### PR TITLE
fix: 承認なしの施設に、承認完了通知が送られてしまうため承認アリの時のみ送るように修正

### DIFF
--- a/Model/Behavior/ReservationMailQueueBehavior.php
+++ b/Model/Behavior/ReservationMailQueueBehavior.php
@@ -48,8 +48,11 @@ class ReservationMailQueueBehavior extends MailQueueBehavior {
 			// --- ワークフローのstatusによって送信内容を変える
 			// 各プラグインが承認機能=ONかどうかは、気にしなくてＯＫ。承認機能=OFFなら status=公開が飛んでくるため。
 
-			// 承認依頼通知, 差戻し通知, 承認完了通知メール(即時)
-			$this->_saveQueueNoticeMail($model, $languageId, $typeKey);
+			//承認ワークフローを使うときのみ承認関連のメールは送らない
+			if ($model->data['ReservationLocation']['use_workflow']) {
+				// 承認依頼通知, 差戻し通知, 承認完了通知メール(即時)
+				$this->_saveQueueNoticeMail($model, $languageId, $typeKey);
+			}
 
 			$mailSettingPlugin = $this->__getMailSettingPlugin($model, $languageId, $typeKey);
 			$isMailSend = Hash::get($mailSettingPlugin, 'MailSetting.is_mail_send');

--- a/Model/ReservationActionPlan.php
+++ b/Model/ReservationActionPlan.php
@@ -1088,7 +1088,6 @@ class ReservationActionPlan extends ReservationsAppModel {
 			CakeLog::error($ex->getMessage());
 			throw($ex);	//再throw
 		}
-		CakeLog::debug(var_export($planParam, true));
 		return $planParam;
 	}
 

--- a/View/Elements/ReservationPlans/detail_edit_mail.ctp
+++ b/View/Elements/ReservationPlans/detail_edit_mail.ctp
@@ -9,23 +9,19 @@
  * @copyright Copyright 2014, NetCommons Project
  */
 ?>
-<?php
-	$checkMailStyle = '';
-	if (!isset($mailSettingInfo['MailSetting']['is_mail_send']) ||
-		$mailSettingInfo['MailSetting']['is_mail_send'] == 0) {
-		$checkMailStyle = "style='display: none;'";
-	}
-?>
 <div class="col-xs-12 col-sm-12">
-	<?php
+<?php
+if (isset($mailSettingInfo['MailSetting']['is_mail_send']) &&
+		$mailSettingInfo['MailSetting']['is_mail_send']) {
 	echo $this->NetCommonsForm->inlineCheckbox('ReservationActionPlan.enable_email', ['label' =>
 	__d(
 		'reservations',
 		'Inform other members by e-mail?'
 	)]);
+} else {
+	echo $this->NetCommonsForm->hidden('ReservationActionPlan.enable_email', array('value' => false));
+}
 
-	//echo $this->NetCommonsForm->hidden('ReservationActionPlan.enable_email', array('value' => false));
-	echo $this->NetCommonsForm->hidden('ReservationActionPlan.email_send_timing', array('value' => 5));
-	?>
-
+echo $this->NetCommonsForm->hidden('ReservationActionPlan.email_send_timing', array('value' => 5));
+?>
 </div>


### PR DESCRIPTION
また、「メール通知機能を使う」がOFFでもメールが送れるUIだったので修正
https://github.com/NetCommons3/NetCommons3/issues/1639