### PR TITLE
fix: カテゴリ別表示の画面遷移不具合の修正

### DIFF
--- a/Controller/ReservationsController.php
+++ b/Controller/ReservationsController.php
@@ -119,6 +119,11 @@ class ReservationsController extends ReservationsAppController {
 		}
 
 		$categoryId = Hash::get($this->request->params['named'], 'category_id');
+		if ($categoryId === '') {
+			// タブ切り替えや前後ページングで'カテゴリ選択'だとcategory_idが空文字になるので
+			// そのときはnull（カテゴリの指定無し）にする
+			$categoryId = null;
+		}
 
 		$locations = $this->ReservationLocation->getLocations($categoryId);
 


### PR DESCRIPTION
カテゴリ別表示で、カテゴリドロップダウンを「カテゴリ選択」のまま週、日表示を切り替えたり、前後にページングすると、表示される施設が「カテゴリ無し」のものになる不具合を修正。