### PR TITLE
fix: 繰り返しの予約を「この予約のみ」で修正すると、同じ予約が2重に表示されるバグ修正

### DIFF
--- a/Controller/ReservationPlansController.php
+++ b/Controller/ReservationPlansController.php
@@ -330,6 +330,10 @@ class ReservationPlansController extends ReservationsAppController {
  */
 	public function edit() {
 		if ($this->request->is('post')) {
+			$editRrule = $this->ReservationActionPlan->getEditRruleForUpdate($this->request->data);
+			if ($editRrule == ReservationAppBehavior::CALENDAR_PLAN_EDIT_THIS) {
+				$this->request->data['ReservationActionPlan']['is_repeat'] = '0';
+			}
 			$this->_reservationPost();
 		}
 		// 表示のための処理

--- a/Model/ReservationActionPlan.php
+++ b/Model/ReservationActionPlan.php
@@ -574,7 +574,7 @@ class ReservationActionPlan extends ReservationsAppModel {
 						// 全ての予約を更新
 						$ignoreConditions = [
 							'NOT' => [
-								'ReservationEvent.rrule_id' =>
+								'ReservationEvent.reservation_rrule_id' =>
 									Hash::get($this->data, 'ReservationActionPlan.origin_rrule_id'),
 								'ReservationEvent.recurrence_event_id !=' => 0,
 								'ReservationEvent.exception_event_id !=' => 0,
@@ -910,9 +910,14 @@ class ReservationActionPlan extends ReservationsAppModel {
 				//3. isMyPrivateRoomは、変更後の公開ルームidが「編集者・承認者（＝ログイン者）のプライベート」以外の場合、
 				//仲間の予定はプライベートの時のみ許される子情報なので、これらはcopy対象から外す（stripする）例外処理用。
 				//
-				$newPlan = $this->makeNewGenPlan($data, $status, $createdUserWhenUpd, $isMyPrivateRoom);
-
 				$editRrule = $this->getEditRruleForUpdate($data);
+				$newPlan = $this->makeNewGenPlan(
+					$data,
+					$status,
+					$createdUserWhenUpd,
+					$isMyPrivateRoom,
+					$editRrule
+				);
 
 				$isInfoArray = array($isOriginRepeat, $isTimeMod, $isRepeatMod, $isMyPrivateRoom);
 				$eventId = $this->updatePlan($planParam, $newPlan, $status, $isInfoArray, $editRrule,

--- a/View/Helper/ReservationPlanEditRepeatOptionHelper.php
+++ b/View/Helper/ReservationPlanEditRepeatOptionHelper.php
@@ -106,7 +106,7 @@ class ReservationPlanEditRepeatOptionHelper extends AppHelper {
 			'ng-model' => 'editRrule',
 			'ng-init' => "editRrule = '" . $editRrule . "'",
 			'ng-change' => "changeEditRrule(" . Current::read('Frame.id') . ",'" . $firstSibEditLink . "')",
-			'ng-click' => 'sending=true',
+			//'ng-click' => 'sending=true',
 		));
 		if (! $isRecurrence) {
 			$html .= '<p class="help-block text-right"><small>';


### PR DESCRIPTION
* 繰り返しの予約編集時に、「この予約のみ」から切り替えるとボタンがDisableになるバグ修正、
* 「設定した全ての予約」で予約を編集するとエラーになる 

https://github.com/NetCommons3/NetCommons3/issues/1721